### PR TITLE
Add Catch2 for unit testing and populate some initial tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       run: conan profile new default --detect
 
     - name: Update profile
-      run: conan profile update settings.compiler.libcxx=libstdc++17 default
+      run: conan profile update settings.compiler.libcxx=libstdc++11 default
 
     - name: Install dependencies
       run: conan install . -s build_type=${{env.BUILD_TYPE}} --install-folder=${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,11 +18,14 @@ jobs:
     - name: Get Conan
       uses: turtlebrowser/get-conan@v1.0
 
+    - name: Create default profile
+      run: conan profile new default --detect
+
+    - name: Update profile
+      run: conan profile update settings.compiler.libcxx=libstdc++17 default
+
     - name: Install dependencies
       run: conan install . -s build_type=${{env.BUILD_TYPE}} --install-folder=${{github.workspace}}/build
-
-    - name: Activate virtual environment
-      run: source ${{github.workspace}}/build/activate.sh
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,36 @@
+name: CMake
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get Conan
+      uses: turtlebrowser/get-conan@v1.0
+
+    - name: Install dependencies
+      run: conan install . -s build_type=${{env.BUILD_TYPE}} --install-folder=${{github.workspace}}/build
+
+    - name: Activate virtual environment
+      run: source ${{github.workspace}}/build/activate.sh
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      run: cmake --build . --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build/tests
+      run: ctest -C ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,11 @@ find_package(nlohmann_json REQUIRED)
 find_package(PNG REQUIRED)
 find_package(tinyobjloader REQUIRED)
 
-# ===== Executable
+# ===== Library
 
-add_executable(ray-tracer)
-set_target_properties(ray-tracer
+add_library(ray-tracer-lib)
+
+set_target_properties(ray-tracer-lib
     PROPERTIES
         CXX_STANDARD 17
 )
@@ -21,18 +22,18 @@ set_target_properties(ray-tracer
 if (UNIX)
     find_package(Threads)
 
-    target_compile_options(ray-tracer
+    target_compile_options(ray-tracer-lib
         PUBLIC
             -march=native
     )
 
-    target_link_libraries(ray-tracer
+    target_link_libraries(ray-tracer-lib
         PRIVATE
             ${CMAKE_THREAD_LIBS_INIT}
     )
 endif()
 
-target_link_libraries(ray-tracer
+target_link_libraries(ray-tracer-lib
     PRIVATE
         nlohmann_json::nlohmann_json
         PNG::PNG
@@ -40,21 +41,19 @@ target_link_libraries(ray-tracer
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries(ray-tracer
+    target_link_libraries(ray-tracer-lib
         PRIVATE
             stdc++fs
     )
 endif()
 
-target_include_directories(ray-tracer
-    PRIVATE
+target_include_directories(ray-tracer-lib
+    PUBLIC
         include/
 )
 
-target_sources(ray-tracer
+target_sources(ray-tracer-lib
     PRIVATE
-        src/main.cpp
-
         include/Pixel.h
 
         include/Image.h
@@ -176,3 +175,24 @@ target_sources(ray-tracer
 
         include/EnumFlag.h
 )
+
+# ===== Executable
+
+add_executable(ray-tracer)
+
+set_target_properties(ray-tracer
+    PROPERTIES
+        CXX_STANDARD 17
+)
+
+target_link_libraries(ray-tracer
+    PRIVATE
+        ray-tracer-lib
+)
+
+target_sources(ray-tracer
+    PRIVATE
+        src/main.cpp
+)
+
+add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (UNIX)
 endif()
 
 target_link_libraries(ray-tracer-lib
-    PRIVATE
+    PUBLIC
         nlohmann_json::nlohmann_json
         PNG::PNG
         tinyobjloader::tinyobjloader

--- a/README.md
+++ b/README.md
@@ -64,3 +64,23 @@ build\Release\ray-tracer.exe test.json
 ```
 build/Release/ray-tracer test.json
 ```
+
+# Testing
+
+The `tests` target is configured along with the main executable above.
+
+```
+cmake --build . --target tests --config Release
+```
+
+## Windows
+
+```
+build\tests\Release\tests.exe -s -d yes
+```
+
+## Linux / macOS
+
+```
+build/tests/Release/tests -s -d yes
+```

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -2,6 +2,7 @@
 libpng/1.6.38
 nlohmann_json/3.11.2
 tinyobjloader/1.0.6
+catch2/3.1.0
 
 [generators]
 cmake_find_package

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 
 Limits::Limits(double imin, double imax) noexcept
-    : min(imin)
-    , max(imax)
+    : min(std::min(imin, imax))
+    , max(std::max(imin, imax))
 {
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 
+enable_testing()
+
 find_package(Catch2 REQUIRED)
 
 add_executable(tests)
@@ -20,3 +22,7 @@ target_sources(tests
         test_Bounds.cpp
         test_main.cpp
 )
+
+include(CTest)
+include(Catch)
+catch_discover_tests(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.17)
 
 enable_testing()
 
-find_package(Catch2 REQUIRED)
+find_package(Catch2 3 REQUIRED)
 
 add_executable(tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.17)
+
+find_package(Catch2 REQUIRED)
+
+add_executable(tests)
+
+target_link_libraries(tests
+    PRIVATE
+        ray-tracer-lib
+        Catch2::Catch2WithMain
+)
+
+set_target_properties(tests
+    PROPERTIES
+        CXX_STANDARD 17
+)
+
+target_sources(tests
+    PRIVATE
+        test_Bounds.cpp
+        test_main.cpp
+)

--- a/tests/test_Bounds.cpp
+++ b/tests/test_Bounds.cpp
@@ -1,0 +1,8 @@
+#include <catch2/catch_all.hpp>
+
+#include "Bounds.h"
+
+TEST_CASE("Catch is working", "")
+{
+    REQUIRE(true);
+}

--- a/tests/test_Bounds.cpp
+++ b/tests/test_Bounds.cpp
@@ -669,12 +669,80 @@ TEST_CASE("Bounds::operator[] returns expected values", "[Bounds]")
 
 TEST_CASE("Bounds::contains returns expected values", "[Bounds]")
 {
+    Limits limitsX{-1.0, 2.0};
+    Limits limitsY{-2.0, 3.0};
+    Limits limitsZ{-3.0, 4.0};
+
+    Bounds bounds{limitsX, limitsY, limitsZ};
+
+    REQUIRE(bounds.contains(Vector()));
+    REQUIRE(bounds.contains(Vector(-1.0, -2.0, -3.0)));
+    REQUIRE(bounds.contains(Vector(2.0, 3.0, 4.0)));
+    REQUIRE(!bounds.contains(Vector(-2.0, -2.0, -3.0)));
+    REQUIRE(!bounds.contains(Vector(3.0, 3.0, 4.0)));
 }
 
 TEST_CASE("Bounds::intersects returns expected values", "[Bounds]")
 {
+    Limits limitsAX{-1.0, 1.0};
+    Limits limitsAY{-1.0, 1.0};
+    Limits limitsAZ{-1.0, 1.0};
+
+    Bounds boundsA{limitsAX, limitsAY, limitsAZ};
+
+    SECTION("Overlapping bounds intersect")
+    {
+        Limits limitsBX{0.0, 2.0};
+        Limits limitsBY{0.0, 2.0};
+        Limits limitsBZ{0.0, 2.0};
+
+        Bounds boundsB{limitsBX, limitsBY, limitsBZ};
+
+        REQUIRE(boundsA.intersects(boundsB));
+        REQUIRE(boundsB.intersects(boundsA));
+    }
+
+    SECTION("Touching bounds intersect")
+    {
+        Limits limitsBX{1.0, 2.0};
+        Limits limitsBY{1.0, 2.0};
+        Limits limitsBZ{1.0, 2.0};
+
+        Bounds boundsB{limitsBX, limitsBY, limitsBZ};
+
+        REQUIRE(boundsA.intersects(boundsB));
+        REQUIRE(boundsB.intersects(boundsA));
+    }
+
+    SECTION("Separate bounds do not intersect")
+    {
+        Limits limitsBX{2.0, 3.0};
+        Limits limitsBY{2.0, 3.0};
+        Limits limitsBZ{2.0, 3.0};
+
+        Bounds boundsB{limitsBX, limitsBY, limitsBZ};
+
+        REQUIRE(!boundsA.intersects(boundsB));
+        REQUIRE(!boundsB.intersects(boundsA));
+    }
 }
 
 TEST_CASE("Bounds::minimum and ::maximum return expected values", "[Bounds]")
 {
+    Limits limitsX{-1.0, 2.0};
+    Limits limitsY{-2.0, 3.0};
+    Limits limitsZ{-3.0, 4.0};
+
+    Bounds bounds{limitsX, limitsY, limitsZ};
+
+    Vector minimum = bounds.minimum();
+    Vector maximum = bounds.maximum();
+
+    REQUIRE_THAT(minimum.x,  WithinULP(limitsX.min, 1));
+    REQUIRE_THAT(minimum.y,  WithinULP(limitsY.min, 1));
+    REQUIRE_THAT(minimum.z,  WithinULP(limitsZ.min, 1));
+
+    REQUIRE_THAT(maximum.x,  WithinULP(limitsX.max, 1));
+    REQUIRE_THAT(maximum.y,  WithinULP(limitsY.max, 1));
+    REQUIRE_THAT(maximum.z,  WithinULP(limitsZ.max, 1));
 }

--- a/tests/test_Bounds.cpp
+++ b/tests/test_Bounds.cpp
@@ -2,7 +2,384 @@
 
 #include "Bounds.h"
 
-TEST_CASE("Catch is working", "")
+using Catch::Matchers::WithinULP;
+
+// zero Limits = {0, 0}
+// single value Limits = {x, x}
+// non-zero Limtis = {x, y}
+
+TEST_CASE("Limits constructors produce expected initial state", "[Limits]")
 {
-    REQUIRE(true);
+    SECTION("default constructor sets min and max to zero")
+    {
+        Limits limits;
+
+        REQUIRE_THAT(limits.min,  WithinULP(0.0, 1));
+        REQUIRE_THAT(limits.max,  WithinULP(0.0, 1));
+    }
+
+    SECTION("min, max constructor sets min and max accordingly")
+    {
+        const double expectedMin = -1.0;
+        const double expectedMax = 1.0;
+
+        Limits limits{expectedMin, expectedMax};
+
+        REQUIRE_THAT(limits.min,  WithinULP(expectedMin, 1));
+        REQUIRE_THAT(limits.max,  WithinULP(expectedMax, 1));
+    }
+
+    SECTION("min, max constructor sets uses minimum value for min and maximum value for max")
+    {
+        const double expectedMin = -1.0;
+        const double expectedMax = 1.0;
+
+        Limits limits{expectedMax, expectedMin};
+
+        REQUIRE_THAT(limits.min,  WithinULP(expectedMin, 1));
+        REQUIRE_THAT(limits.max,  WithinULP(expectedMax, 1));
+    }
+
+    SECTION("value constructor sets min and max to value")
+    {
+        const double expectedValue = 1.0;
+
+        Limits limits{expectedValue};
+
+        REQUIRE_THAT(limits.min,  WithinULP(expectedValue, 1));
+        REQUIRE_THAT(limits.max,  WithinULP(expectedValue, 1));
+    }
+
+    SECTION("0 value constructor equivalent to default constructor")
+    {
+        Limits limitsA{0.0};
+        Limits limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(limitsB.min, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(limitsB.max, 1));
+    }
+}
+
+TEST_CASE("Limits::contains method produces expected values with non-zero range", "[Limits]")
+{
+    const double belowMin = -2.0;
+    const double limitsMin = -1.0;
+    const double limitsMax = 1.0;
+    const double aboveMax = 2.0;
+
+    Limits limits{limitsMin, limitsMax};
+
+    SECTION("value equal to min is contained")
+    {
+        REQUIRE(limits.contains(limitsMin));
+    }
+
+    SECTION("value equal to max is contained")
+    {
+        REQUIRE(limits.contains(limitsMax));
+    }
+
+    SECTION("value within min and max is contained")
+    {
+        REQUIRE(limits.contains(0.0));
+    }
+
+    SECTION("value below min is not contained")
+    {
+        REQUIRE(!limits.contains(belowMin));
+    }
+
+    SECTION("value above max is not contained")
+    {
+        REQUIRE(!limits.contains(aboveMax));
+    }
+}
+
+TEST_CASE("Limits::contains method produces expected values with zero range", "[Limits]")
+{
+    const double belowMin = -1.0;
+    const double aboveMax = 1.0;
+
+    Limits limits;
+
+    SECTION("value equal to min is contained")
+    {
+        REQUIRE(limits.contains(0.0));
+    }
+
+    SECTION("value equal to max is contained")
+    {
+        REQUIRE(limits.contains(0.0));
+    }
+
+    SECTION("value within min and max is contained")
+    {
+        REQUIRE(limits.contains(0.0));
+    }
+
+    SECTION("value below min is not contained")
+    {
+        REQUIRE(!limits.contains(belowMin));
+    }
+
+    SECTION("value above max is not contained")
+    {
+        REQUIRE(!limits.contains(aboveMax));
+    }
+}
+
+TEST_CASE("Limits::intersects method produces expected values", "[Limits]")
+{
+    SECTION("equivalent Limits intersect")
+    {
+        SECTION("equivalent zero Limits intersect")
+        {
+            Limits limitsA;
+            Limits limitsB;
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("equivalent single value Limits intersect")
+        {
+            Limits limitsA{1.0};
+            Limits limitsB{1.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("equivalent non-zero Limits intersect")
+        {
+            Limits limitsA{-1.0, 1.0};
+            Limits limitsB{-1.0, 1.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+    }
+
+    SECTION("overlapping Limits intersect")
+    {
+        SECTION("zero overlapping single value Limits intersect")
+        {
+            Limits limitsA;
+            Limits limitsB{0.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("zero overlapping non-zero Limits intersect")
+        {
+            Limits limitsA;
+            Limits limitsB{-1.0, 1.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("single value overlapping non-zero Limits intersect")
+        {
+            Limits limitsA{0.5};
+            Limits limitsB{-1.0, 1.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("overlapping non-zero Limits intersect")
+        {
+            Limits limitsA{-1.0, 1.0};
+            Limits limitsB{-2.0, 0.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+    }
+
+    SECTION("touching Limits intersect")
+    {
+        SECTION("zero touching single value Limits intersect")
+        {
+            Limits limitsA;
+            Limits limitsB{0.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("zero touching non-zero Limits intersect")
+        {
+            Limits limitsA;
+            Limits limitsB{0.0, 1.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("single value touching non-zero Limits intersect")
+        {
+            Limits limitsA{1.0};
+            Limits limitsB{-1.0, 1.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+
+        SECTION("touching non-zero Limits intersect")
+        {
+            Limits limitsA{-1.0, 0.0};
+            Limits limitsB{0.0, 1.0};
+
+            REQUIRE(limitsA.intersects(limitsB));
+            REQUIRE(limitsB.intersects(limitsA));
+        }
+    }
+
+    SECTION("separated Limits do not intersect")
+    {
+        SECTION("zero separated from single value Limits do not intersect")
+        {
+            Limits limitsA;
+            Limits limitsB{1.0};
+
+            REQUIRE(!limitsA.intersects(limitsB));
+            REQUIRE(!limitsB.intersects(limitsA));
+        }
+
+        SECTION("zero separated from non-zero Limits do not intersect")
+        {
+            Limits limitsA;
+            Limits limitsB{1.0, 2.0};
+
+            REQUIRE(!limitsA.intersects(limitsB));
+            REQUIRE(!limitsB.intersects(limitsA));
+        }
+
+        SECTION("single value separated from non-zero Limits do not intersect")
+        {
+            Limits limitsA{2.0};
+            Limits limitsB{-1.0, 1.0};
+
+            REQUIRE(!limitsA.intersects(limitsB));
+            REQUIRE(!limitsB.intersects(limitsA));
+        }
+
+        SECTION("separated from non-zero Limits do not intersect")
+        {
+            Limits limitsA{-2.0, -1.0};
+            Limits limitsB{0.0, 1.0};
+
+            REQUIRE(!limitsA.intersects(limitsB));
+            REQUIRE(!limitsB.intersects(limitsA));
+        }
+    }
+}
+
+TEST_CASE("Limits assignment operator produces expected values", "[Limits]")
+{
+    Limits limitsA;
+    Limits limitsB{-1.0, 1.0};
+
+    limitsA = limitsB;
+
+    SECTION("assignment sets min and max equal to the right hand side Limits")
+    {
+        REQUIRE_THAT(limitsA.min,  WithinULP(limitsB.min, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(limitsB.max, 1));
+    }
+
+    SECTION("assignment copies value from right hand side Limits")
+    {
+        limitsA.min = -2.0;
+        limitsA.max = -1.0;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-2.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(-1.0, 1));
+
+        REQUIRE_THAT(limitsB.min,  WithinULP(-1.0, 1));
+        REQUIRE_THAT(limitsB.max,  WithinULP(1.0, 1));
+    }
+}
+
+TEST_CASE("Limits addition assignment operator extends range", "[Limits]")
+{
+    SECTION("equivalent addition assignment produces no change")
+    {
+        Limits limitsA{-1.0, 1.0};
+        Limits limitsB{-1.0, 1.0};
+
+        limitsA += limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-1.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(1.0, 1));
+    }
+
+    SECTION("addition assignment with lower min extends min")
+    {
+        Limits limitsA{-1.0, 1.0};
+        Limits limitsB{-2.0, 1.0};
+
+        limitsA += limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-2.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(1.0, 1));
+    }
+
+    SECTION("addition assignment with higher min does nothing")
+    {
+        Limits limitsA{-1.0, 1.0};
+        Limits limitsB{0.0, 1.0};
+
+        limitsA += limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-1.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(1.0, 1));
+    }
+
+    SECTION("addition assignment with higher max extends max")
+    {
+        Limits limitsA{-1.0, 1.0};
+        Limits limitsB{-1.0, 2.0};
+
+        limitsA += limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-1.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(2.0, 1));
+    }
+
+    SECTION("addition assignment with lower max does nothing")
+    {
+        Limits limitsA{-1.0, 1.0};
+        Limits limitsB{-1.0, 0.0};
+
+        limitsA += limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-1.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(1.0, 1));
+    }
+
+    SECTION("addition assignment with wider range extends min and max")
+    {
+        Limits limitsA{-1.0, 1.0};
+        Limits limitsB{-2.0, 2.0};
+
+        limitsA += limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-2.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(2.0, 1));
+    }
+
+    SECTION("addition assignment with contained range does nothing")
+    {
+        Limits limitsA{-2.0, 2.0};
+        Limits limitsB{-1.0, 1.0};
+
+        limitsA += limitsB;
+
+        REQUIRE_THAT(limitsA.min,  WithinULP(-2.0, 1));
+        REQUIRE_THAT(limitsA.max,  WithinULP(2.0, 1));
+    }
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>


### PR DESCRIPTION
### What

* Add Catch2 library for unit testing
* Move `ray-tracer` sources to new library `ray-tracer-lib` to facilitate unit testing
* Add scaffold test to verify target is building and running correctly
  - Updated README with instructions to build and run tests.
* Ensure `Limits::min` and `Limits::max` use the right values in the `Limits(min, max)` constructor
  - `Limits::min` should be the minimum of the provided min and max, `Limits::max` should be the maximum of the provided min and max.
* Fill out unit test suite for `Limits` structure
* Populating tests for `Bounds`